### PR TITLE
Michael Sheely Pull Request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,3 +10,5 @@ name = "nom"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ nom = "^1.2.4"
 [[bin]]
 name = "repl"
 path = "src/repl.rs"
+
+[[bin]]
+name = "stat"
+path = "src/stat.rs"
+

--- a/src/expr/expr.rs
+++ b/src/expr/expr.rs
@@ -30,13 +30,19 @@ impl Expr {
     /// Computes the number of binary operations.
     /// For example, `1+4-5` has two operations.
     pub fn operation_count(&self) -> usize {
-        unimplemented!()
+        match *self {
+            Expr::Literal(_) => 0,
+            Expr::BinOp(ref x, _, ref y) => 1 + x.operation_count() + y.operation_count()
+        }
     }
 
     /// The depth, defined as `max{ # of operations from root to leaf }`.
     /// `1` has depth 0, `1+3` has depth 1, and `1+4*3` has depth 2
     pub fn depth(&self) -> usize {
-        unimplemented!()
+        match *self {
+            Expr::Literal(_) => 0,
+            Expr::BinOp(ref x, _, ref y) => 1 + 
+        }
     }
 }
 

--- a/src/expr/expr.rs
+++ b/src/expr/expr.rs
@@ -39,9 +39,10 @@ impl Expr {
     /// The depth, defined as `max{ # of operations from root to leaf }`.
     /// `1` has depth 0, `1+3` has depth 1, and `1+4*3` has depth 2
     pub fn depth(&self) -> usize {
+        use std::cmp;
         match *self {
             Expr::Literal(_) => 0,
-            Expr::BinOp(ref x, _, ref y) => 1 + 
+            Expr::BinOp(ref x, _, ref y) => 1 + cmp::max(x.depth(), y.depth())
         }
     }
 }

--- a/src/expr/expr.rs
+++ b/src/expr/expr.rs
@@ -17,6 +17,7 @@ pub enum BinOp {
 }
 
 impl Expr {
+    /// Evalutes the arithmentic expression.
     pub fn evaluate(&self) -> isize {
         match *self {
             Expr::BinOp(ref x, BinOp::Plus,  ref y) => x.evaluate() + y.evaluate(),

--- a/src/expr/expr.rs
+++ b/src/expr/expr.rs
@@ -1,16 +1,17 @@
-// Alex Ozdemir <aozdemir@hmc.edu> // <- Your name should replace this line!
-// Starter code for HMC's MemorySafe, week 2
+// Michael Sheely <msheely@hmc.edu>
+// HMC's MemorySafe, week 2
 //
-// The definition of `Expr`, a type that represents arithmetic expressions involving +,-,*,/, in
-// terms of those operations.
+// The definition of `Expr`, a type that represents arithmetic expressions
+// involving +,-,*,/, in terms of those operations.
+//
+// Also provides functions for getting statistics about an Expr and
+// evaluating them to an isize.
 
-#[derive(Debug)]
 pub enum Expr {
     BinOp(Box<Expr>, BinOp, Box<Expr>),
     Literal(isize),
 }
 
-#[derive(Debug)]
 pub enum BinOp {
     Plus,
     Minus,
@@ -22,10 +23,14 @@ impl Expr {
     /// Evalutes the arithmentic expression.
     pub fn evaluate(&self) -> isize {
         match *self {
-            Expr::BinOp(ref x, BinOp::Plus,  ref y) => x.evaluate() + y.evaluate(),
-            Expr::BinOp(ref x, BinOp::Minus, ref y) => x.evaluate() - y.evaluate(),
-            Expr::BinOp(ref x, BinOp::Times, ref y) => x.evaluate() * y.evaluate(),
-            Expr::BinOp(ref x, BinOp::Over,  ref y) => x.evaluate() / y.evaluate(),
+            Expr::BinOp(ref x, BinOp::Plus,  ref y) =>
+                x.evaluate() + y.evaluate(),
+            Expr::BinOp(ref x, BinOp::Minus, ref y) =>
+                x.evaluate() - y.evaluate(),
+            Expr::BinOp(ref x, BinOp::Times, ref y) =>
+                x.evaluate() * y.evaluate(),
+            Expr::BinOp(ref x, BinOp::Over,  ref y) =>
+                x.evaluate() / y.evaluate(),
             Expr::Literal(num) => num
         }
     }
@@ -35,7 +40,8 @@ impl Expr {
     pub fn operation_count(&self) -> usize {
         match *self {
             Expr::Literal(_) => 0,
-            Expr::BinOp(ref x, _, ref y) => 1 + x.operation_count() + y.operation_count()
+            Expr::BinOp(ref x, _, ref y) =>
+                1 + x.operation_count() + y.operation_count()
         }
     }
 

--- a/src/expr/expr.rs
+++ b/src/expr/expr.rs
@@ -18,7 +18,7 @@ pub enum BinOp {
 
 impl Expr {
     pub fn evaluate(&self) -> isize {
-        unimplemented!()
+        42
     }
 
     /// Computes the number of binary operations.

--- a/src/expr/expr.rs
+++ b/src/expr/expr.rs
@@ -18,7 +18,13 @@ pub enum BinOp {
 
 impl Expr {
     pub fn evaluate(&self) -> isize {
-        42
+        match *self {
+            Expr::BinOp(ref x, BinOp::Plus,  ref y) => x.evaluate() + y.evaluate(),
+            Expr::BinOp(ref x, BinOp::Minus, ref y) => x.evaluate() - y.evaluate(),
+            Expr::BinOp(ref x, BinOp::Times, ref y) => x.evaluate() * y.evaluate(),
+            Expr::BinOp(ref x, BinOp::Over,  ref y) => x.evaluate() / y.evaluate(),
+            Expr::Literal(num) => num
+        }
     }
 
     /// Computes the number of binary operations.

--- a/src/expr/expr.rs
+++ b/src/expr/expr.rs
@@ -4,11 +4,13 @@
 // The definition of `Expr`, a type that represents arithmetic expressions involving +,-,*,/, in
 // terms of those operations.
 
+#[derive(Debug)]
 pub enum Expr {
     BinOp(Box<Expr>, BinOp, Box<Expr>),
     Literal(isize),
 }
 
+#[derive(Debug)]
 pub enum BinOp {
     Plus,
     Minus,

--- a/src/expr/parser.rs
+++ b/src/expr/parser.rs
@@ -1,15 +1,15 @@
 // Michael Sheely <msheely@hmc.edu>
 // Parsing assinment for HMC's MemorySafe, week 2
 //
-// The parser for an `Expr` (currently just produces the value fo the `Expr`)
+// The parser for an `Expr` (does not allow for whitespace).
 
 use expr::Expr;
 use expr::BinOp;
 
 use nom::digit;
 
-use std::str;
 use std::mem;
+use std::str;
 use std::str::FromStr;
 
 named!(parens<Expr>, delimited!(
@@ -41,35 +41,41 @@ named!(factor<Expr>,
 named!(term <Expr>,
   chain!(
     mut acc: factor  ~
-             many0!(
-               alt!(
-                 map!(preceded!(tag!("*"), term), |prod: Expr| {
-                     match acc {
-                         Expr::Literal(num) => {
-                           acc = Expr::BinOp(Box::new(Expr::Literal(num)), BinOp::Times, Box::new(prod));
-                         },
-                         Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
-                             // swap out each of acc's values
-                             let inner_x = mem::replace(x, Box::new(prod));
-                             let inner_op = mem::replace(op, BinOp::Times);
-                             let inner_y = mem::replace(y, Box::new(Expr::Literal(0)));
-                             mem::replace(y, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
-                         }
-                     }}) |
-                 map!(preceded!(tag!("/"), term), |div: Expr| {
-                     match acc {
-                         Expr::Literal(num) => {
-                           acc = Expr::BinOp(Box::new(Expr::Literal(num)), BinOp::Over, Box::new(div));
-                         },
-                         Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
-                           let inner_x = mem::replace(x, Box::new(Expr::Literal(0)));
-                           let inner_op = mem::replace(op, BinOp::Over);
-                           let inner_y = mem::replace(y, Box::new(div));
-                           mem::replace(x, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
-                         }
-                 }})
-               )
-             ),
+      many0!(
+        alt!(
+          map!(preceded!(tag!("*"), term), |prod: Expr| {
+            match acc {
+              Expr::Literal(num) => {
+                acc = Expr::BinOp(Box::new(Expr::Literal(num)),
+                                  BinOp::Times, Box::new(prod));
+              },
+              Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
+                // swap out each of acc's values
+                let inner_x = mem::replace(x, Box::new(prod));
+                let inner_op = mem::replace(op, BinOp::Times);
+                let inner_y = mem::replace(y, Box::new(Expr::Literal(0)));
+                mem::replace(y, Box::new(
+                        Expr::BinOp(inner_x, inner_op, inner_y)));
+              }
+            }
+          }) |
+          map!(preceded!(tag!("/"), term), |div: Expr| {
+            match acc {
+              Expr::Literal(num) => {
+                acc = Expr::BinOp(Box::new(Expr::Literal(num)), BinOp::Over,
+                                  Box::new(div));
+              },
+              Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
+                let inner_x = mem::replace(x, Box::new(Expr::Literal(0)));
+                let inner_op = mem::replace(op, BinOp::Over);
+                let inner_y = mem::replace(y, Box::new(div));
+                mem::replace(x, Box::new(
+                        Expr::BinOp(inner_x, inner_op, inner_y)));
+              }
+            }
+          })
+        )
+      ),
     || { return acc }
   )
 );
@@ -77,35 +83,41 @@ named!(term <Expr>,
 named!(pub expr <Expr>,
   chain!(
     mut acc: term  ~
-             many0!(
-               alt!(
-                 map!(preceded!(tag!("+"), term), |add: Expr| {
-                     match acc {
-                         Expr::Literal(num) => {
-                           acc = Expr::BinOp(Box::new(Expr::Literal(num)), BinOp::Plus, Box::new(add));
-                         },
-                         Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
-                             // swap out each of acc's values
-                             let inner_x = mem::replace(x, Box::new(add));
-                             let inner_op = mem::replace(op, BinOp::Plus);
-                             let inner_y = mem::replace(y, Box::new(Expr::Literal(0)));
-                             mem::replace(y, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
-                         }
-                     }}) |
-                 map!(preceded!(tag!("-"), term), |sub: Expr| {
-                     match acc {
-                         Expr::Literal(num) => {
-                           acc = Expr::BinOp(Box::new(Expr::Literal(num)), BinOp::Minus, Box::new(sub));
-                         },
-                         Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
-                           let inner_y = mem::replace(y, Box::new(sub));
-                           let inner_op = mem::replace(op, BinOp::Minus);
-                           let inner_x = mem::replace(x, Box::new(Expr::Literal(0)));
-                           mem::replace(x, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
-                         }
-                 }})
-               )
-             ),
+      many0!(
+        alt!(
+          map!(preceded!(tag!("+"), term), |add: Expr| {
+            match acc {
+              Expr::Literal(num) => {
+                acc = Expr::BinOp(Box::new(Expr::Literal(num)), BinOp::Plus,
+                                  Box::new(add));
+              },
+              Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
+                // swap out each of acc's values
+                let inner_x = mem::replace(x, Box::new(add));
+                let inner_op = mem::replace(op, BinOp::Plus);
+                let inner_y = mem::replace(y, Box::new(Expr::Literal(0)));
+                mem::replace(y, Box::new(
+                        Expr::BinOp(inner_x, inner_op, inner_y)));
+              }
+            }
+          }) |
+          map!(preceded!(tag!("-"), term), |sub: Expr| {
+            match acc {
+              Expr::Literal(num) => {
+                acc = Expr::BinOp(Box::new(Expr::Literal(num)), BinOp::Minus,
+                                  Box::new(sub));
+              },
+              Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
+                let inner_y = mem::replace(y, Box::new(sub));
+                let inner_op = mem::replace(op, BinOp::Minus);
+                let inner_x = mem::replace(x, Box::new(Expr::Literal(0)));
+                mem::replace(x, Box::new(
+                        Expr::BinOp(inner_x, inner_op, inner_y)));
+              }
+            }
+          })
+        )
+      ),
     || { return acc }
   )
 );

--- a/src/expr/parser.rs
+++ b/src/expr/parser.rs
@@ -1,58 +1,65 @@
-// Alex Ozdemir <aozdemir@hmc.edu> // <- Your name should replace this line!
-// Starter code for HMC's MemorySafe, week 2
+// Michael Sheely <msheely@hmc.edu>
+// Parsing assinment for HMC's MemorySafe, week 2
 //
 // The parser for an `Expr` (currently just produces the value fo the `Expr`)
+
+use expr::Expr;
 
 use nom::digit;
 
 use std::str;
 use std::str::FromStr;
 
-named!(parens<i64>, delimited!(
+named!(parens<Expr>, delimited!(
     char!('('),
     expr,
     char!(')')
   )
 );
 
-named!(i64_literal<i64>,
-  map_res!(
+named!(parse_isize<isize>,
     map_res!(
-      digit,
-      str::from_utf8
-    ),
-    FromStr::from_str
-  )
+      map_res!(digit, str::from_utf8),
+      FromStr::from_str
+    )
 );
 
-named!(factor<i64>,
+named!(isize_literal<Expr>,
+    map!(parse_isize, |x| Expr::Literal(x))
+);
+
+named!(factor<Expr>,
   alt!(
-    i64_literal
+    isize_literal
   | parens
   )
 );
 
 // we define acc as mutable to update its value whenever a new term is found
-named!(term <i64>,
+named!(term <Expr>,
   chain!(
     mut acc: factor  ~
              many0!(
                alt!(
-                 tap!(mul: preceded!(tag!("*"), factor) => acc = acc * mul) |
-                 tap!(div: preceded!(tag!("/"), factor) => acc = acc / div)
+                 //tap!(mul: preceded!(tag!("*"), factor) => acc = acc * mul) |
+                 tap!(mul: preceded!(tag!("*"), factor) => acc = Expr::Literal(4)) |
+                 //tap!(div: preceded!(tag!("/"), factor) => acc = acc / div) |
+                 tap!(div: preceded!(tag!("/"), factor) => acc = Expr::Literal(5))
                )
              ),
     || { return acc }
   )
 );
 
-named!(pub expr <i64>,
+named!(pub expr <Expr>,
   chain!(
     mut acc: term  ~
              many0!(
                alt!(
-                 tap!(add: preceded!(tag!("+"), term) => acc = acc + add) |
-                 tap!(sub: preceded!(tag!("-"), term) => acc = acc - sub)
+                 //tap!(add: preceded!(tag!("+"), term) => acc = acc + add) |
+                 tap!(add: preceded!(tag!("+"), term) => acc = Expr::Literal(2)) |
+                 //tap!(sub: preceded!(tag!("-"), term) => acc = acc - sub)
+                 tap!(sub: preceded!(tag!("-"), term) => acc = Expr::Literal(3))
                )
              ),
     || { return acc }

--- a/src/expr/parser.rs
+++ b/src/expr/parser.rs
@@ -50,10 +50,10 @@ named!(term <Expr>,
                          },
                          Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
                              // swap out each of acc's values
-                             let xx = mem::replace(x, Box::new(prod));
-                             let oper = mem::replace(op, BinOp::Times);
-                             let yy = mem::replace(y, Box::new(Expr::Literal(0)));
-                             mem::replace(y, Box::new(Expr::BinOp(xx, oper, yy)));
+                             let inner_x = mem::replace(x, Box::new(prod));
+                             let inner_op = mem::replace(op, BinOp::Times);
+                             let inner_y = mem::replace(y, Box::new(Expr::Literal(0)));
+                             mem::replace(y, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
                          }
                      }}) |
                  map!(preceded!(tag!("/"), term), |div: Expr| {
@@ -62,10 +62,10 @@ named!(term <Expr>,
                            acc = Expr::BinOp(Box::new(Expr::Literal(num)), BinOp::Over, Box::new(div));
                          },
                          Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
-                           let yy = mem::replace(x, Box::new(Expr::Literal(0)));
-                           let oper = mem::replace(op, BinOp::Over);
-                           let xx = mem::replace(y, Box::new(div));
-                           mem::replace(x, Box::new(Expr::BinOp(xx, oper, yy)));
+                           let inner_x = mem::replace(x, Box::new(Expr::Literal(0)));
+                           let inner_op = mem::replace(op, BinOp::Over);
+                           let inner_y = mem::replace(y, Box::new(div));
+                           mem::replace(y, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
                          }
                  }})
                )
@@ -86,10 +86,10 @@ named!(pub expr <Expr>,
                          },
                          Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
                              // swap out each of acc's values
-                             let xx = mem::replace(x, Box::new(add));
-                             let oper = mem::replace(op, BinOp::Plus);
-                             let yy = mem::replace(y, Box::new(Expr::Literal(0)));
-                             mem::replace(y, Box::new(Expr::BinOp(xx, oper, yy)));
+                             let inner_x = mem::replace(x, Box::new(add));
+                             let inner_op = mem::replace(op, BinOp::Plus);
+                             let inner_y = mem::replace(y, Box::new(Expr::Literal(0)));
+                             mem::replace(y, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
                          }
                      }}) |
                  map!(preceded!(tag!("-"), term), |sub: Expr| {
@@ -98,10 +98,10 @@ named!(pub expr <Expr>,
                            acc = Expr::BinOp(Box::new(Expr::Literal(num)), BinOp::Minus, Box::new(sub));
                          },
                          Expr::BinOp(ref mut x, ref mut op, ref mut y) => {
-                           let yy = mem::replace(x, Box::new(Expr::Literal(0)));
-                           let oper = mem::replace(op, BinOp::Minus);
-                           let xx = mem::replace(y, Box::new(sub));
-                           mem::replace(x, Box::new(Expr::BinOp(xx, oper, yy)));
+                           let inner_y = mem::replace(y, Box::new(sub));
+                           let inner_op = mem::replace(op, BinOp::Minus);
+                           let inner_x = mem::replace(x, Box::new(Expr::Literal(0)));
+                           mem::replace(x, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
                          }
                  }})
                )

--- a/src/expr/parser.rs
+++ b/src/expr/parser.rs
@@ -65,7 +65,7 @@ named!(term <Expr>,
                            let inner_x = mem::replace(x, Box::new(Expr::Literal(0)));
                            let inner_op = mem::replace(op, BinOp::Over);
                            let inner_y = mem::replace(y, Box::new(div));
-                           mem::replace(y, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
+                           mem::replace(x, Box::new(Expr::BinOp(inner_x, inner_op, inner_y)));
                          }
                  }})
                )

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,4 +1,4 @@
-// Alex Ozdemir <aozdemir@hmc.edu> // <- Your name should replace this line!
+// Michael Sheely <msheely@hmc.edu>
 // Starter code for HMC's MemorySafe, week 2
 //
 // The Read Evaluate Print Loop
@@ -17,7 +17,7 @@ fn main() {
     while io::stdin().read_line(&mut line).map(|l| l > 0).unwrap_or(false) {
 
         match expr::parse(line.as_str().trim().as_bytes()) {
-            IResult::Done(rest, res) if rest.len() == 0 => println!("{}", res),
+            IResult::Done(rest, ref res) if rest.len() == 0 => println!("{}", res.evaluate()),
             _ => println!("Error"),
         }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -17,7 +17,8 @@ fn main() {
     while io::stdin().read_line(&mut line).map(|l| l > 0).unwrap_or(false) {
 
         match expr::parse(line.as_str().trim().as_bytes()) {
-            IResult::Done(rest, ref res) if rest.len() == 0 => println!("{}", res.evaluate()),
+            IResult::Done(rest, ref res) if rest.len() == 0 =>
+                println!("{}", res.evaluate()),
             _ => println!("Error"),
         }
 

--- a/src/rexpr.rs
+++ b/src/rexpr.rs
@@ -1,7 +1,8 @@
 // Alex Ozdemir <aozdemir@hmc.edu> // <- Your name should replace this line!
 // Starter code for HMC's MemorySafe, week 2
 //
-// The definition of `RExpr` (ReducedExpr), a type that represents arithmetic expressions involving
+// The definition of `RExpr` (ReducedExpr), a type that represents arithmetic
+// expressions involving
 // +,-,*,/, in terms of Addition, Multiplication, Negation, and Reciprocal
 
 pub enum RExpr {

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -18,7 +18,8 @@ fn main() {
 
         match expr::parse(line.as_str().trim().as_bytes()) {
             IResult::Done(rest, ref res) if rest.len() == 0 =>
-                println!("{} {} {}", res.evaluate(), res.depth(), res.operation_count()),
+                println!("{} {} {}", res.evaluate(), res.depth(),
+                         res.operation_count()),
             _ => println!("Error"),
         }
 

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -1,0 +1,27 @@
+// Michael Sheely <msheely@hmc.edu>
+// Implements the statistics printing for HMC's MemorySafe, week 2
+//
+// The prints statistics for an expression withing a Read Evaluate Print Loop
+
+#[macro_use]
+extern crate nom;
+
+mod expr;
+
+use nom::IResult;
+use std::io;
+
+fn main() {
+    let mut line = String::new();
+
+    while io::stdin().read_line(&mut line).map(|l| l > 0).unwrap_or(false) {
+
+        match expr::parse(line.as_str().trim().as_bytes()) {
+            IResult::Done(rest, ref res) if rest.len() == 0 =>
+                println!("{} {} {}", res.evaluate(), res.depth(), res.operation_count()),
+            _ => println!("Error"),
+        }
+
+        line.clear();
+    }
+}


### PR DESCRIPTION
Got help from Jackson Warely, Ross Mawhorter, and Alex Ozdemir.

Not sure how exactly we were supposed to do the Bonus B, it said to "include a discussion of the methods you considered and their properties."

I don't have a very complete discussion here, and I didn't implement any of it, but I was thinking that we could want to add to our parser two combinators in particular, `nom::opt!` and `nom::char!`.  These work well together because we would want the parsing to succeed whether or not the user input a space to separate things.  We probably do not want to allow the user to input spaces between their numbers, since this would look rather strange and might result in unintuitive behavior for the user.  Essentially we could add -- using the `~` separator -- an `opt!(char!(' '))` combinator on either side of the `tag!("+")` combinator (we would also want to throw away the result of parsing the empty space), and between the parenthesis of the `parens` parser.

I'm so sorry about the inelegance of my four calls to replace for each combinator.  I know there's got to be a better way! (And I guess I'll check out the sample solution after I've submitted this to see what it is!).